### PR TITLE
[IIIF-119] Configure router with OpenAPI spec

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/manifeststore/Op.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/Op.java
@@ -5,6 +5,14 @@ public final class Op {
 
     public static final String GET_PING = "getPing";
 
+    public static final String GET_MANIFEST = "getManifest";
+
+    public static final String PUT_MANIFEST = "putManifest";
+
+    public static final String POST_MANIFEST = "postManifest";
+
+    public static final String DELETE_MANIFEST = "deleteManifest";
+
     public static final String SUCCESS = "success";
 
     public static final String FAILURE = "failure";

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/AbstractManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/AbstractManifestHandler.java
@@ -1,0 +1,29 @@
+
+package edu.ucla.library.iiif.manifeststore.handlers;
+
+import com.amazonaws.regions.RegionUtils;
+
+import info.freelibrary.vertx.s3.S3Client;
+
+import edu.ucla.library.iiif.manifeststore.Config;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+abstract class AbstractManifestHandler implements Handler<RoutingContext> {
+
+    protected S3Client myS3Client;
+
+    AbstractManifestHandler(final Vertx aVertx, final JsonObject aConfig) {
+        if (myS3Client == null) {
+            final String s3AccessKey = aConfig.getString(Config.S3_ACCESS_KEY);
+            final String s3SecretKey = aConfig.getString(Config.S3_SECRET_KEY);
+            final String s3RegionName = aConfig.getString(Config.S3_REGION);
+            final String s3Region = RegionUtils.getRegion(s3RegionName).getServiceEndpoint("s3");
+
+            myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey, s3Region);
+        }
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/DeleteManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/DeleteManifestHandler.java
@@ -1,0 +1,32 @@
+
+package edu.ucla.library.iiif.manifeststore.handlers;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A IIIF manifest deleter.
+ */
+public class DeleteManifestHandler extends AbstractManifestHandler {
+
+    /**
+     * Creates a handler that deletes IIIF manifests from the manifest store.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig A JSON configuration
+     */
+    public DeleteManifestHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final HttpServerResponse response = aContext.response();
+
+        response.setStatusCode(200);
+        response.putHeader("content-type", "text/plain").end("Success!");
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/GetManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/GetManifestHandler.java
@@ -1,0 +1,32 @@
+
+package edu.ucla.library.iiif.manifeststore.handlers;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A IIIF manifest retriever.
+ */
+public class GetManifestHandler extends AbstractManifestHandler {
+
+    /**
+     * Creates a handler that returns IIIF manifests from the manifest store.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig A JSON configuration
+     */
+    public GetManifestHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final HttpServerResponse response = aContext.response();
+
+        response.setStatusCode(200);
+        response.putHeader("content-type", "text/plain").end("Success!");
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/PostManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/PostManifestHandler.java
@@ -1,0 +1,32 @@
+
+package edu.ucla.library.iiif.manifeststore.handlers;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A IIIF manifest creator.
+ */
+public class PostManifestHandler extends AbstractManifestHandler {
+
+    /**
+     * Creates a handler that creates IIIF manifests in the manifest store.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig A JSON configuration
+     */
+    public PostManifestHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final HttpServerResponse response = aContext.response();
+
+        response.setStatusCode(200);
+        response.putHeader("content-type", "text/plain").end("Success!");
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/PutManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/PutManifestHandler.java
@@ -1,0 +1,32 @@
+
+package edu.ucla.library.iiif.manifeststore.handlers;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A manifest creator or updater.
+ */
+public class PutManifestHandler extends AbstractManifestHandler {
+
+    /**
+     * Creates a handler that creates or updates IIIF manifests in the manifest store.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig A JSON configuration
+     */
+    public PutManifestHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final HttpServerResponse response = aContext.response();
+
+        response.setStatusCode(200);
+        response.putHeader("content-type", "text/plain").end("Success!");
+    }
+
+}

--- a/src/main/resources/manifeststore_messages.xml
+++ b/src/main/resources/manifeststore_messages.xml
@@ -12,5 +12,6 @@
 
   <!-- Messages to be stored in the MessageCodes class -->
   <entry key="MFS-000">{}</entry>
+  <entry key="MFS-001">S3 Client configured for region: {}</entry>
 
 </properties>


### PR DESCRIPTION
This just connects the OpenAPI spec created in IIIF-118 to the router created in IIIF-121. I've added stubs for the handlers (that each have their own tickets) and created an abstract class to abstract away the S3 communications from the individual handlers (this will be fleshed out with the handlers tickets).