### PR TITLE
[IIIF-240] Add get and delete handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A IIIF manifest storage microservice. It will provide full CRUD access to a collection of IIIF manifest files. This is a work in progress.
 
+## Configuring the Build
+
+The IIIF manifest store uses an S3 bucket for back-end storage. To be able to run the project's tests, several configuration values must be supplied:
+
+* manifeststore.s3.bucket
+* manifeststore.s3.access_key
+* manifeststore.s3.secret_key
+* manifeststore.s3.region
+
+These values can be set as properties in your system's Maven settings.xml file (or be supplied on the command line at build time).
+
 ## Building the Project
 
 The project builds an executable Jar that can be run to start the microservice. To build the project, run:

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
     <main.verticle>edu.ucla.library.iiif.manifeststore.verticles.MainVerticle</main.verticle>
 
     <!-- AWS configuration properties -->
-    <manifeststore.s3.region>us-west-2</manifeststore.s3.region>
-    <manifeststore.s3.bucket>iiif-manifests</manifeststore.s3.bucket>
+    <manifeststore.s3.region>us-east-1</manifeststore.s3.region>
+    <manifeststore.s3.bucket>iiif-manifest-store</manifeststore.s3.bucket>
     <manifeststore.s3.access_key>YOUR_ACCESS_KEY</manifeststore.s3.access_key>
     <manifeststore.s3.secret_key>YOUR_SECRET_KEY</manifeststore.s3.secret_key>
   </properties>

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/Constants.java
@@ -17,8 +17,24 @@ public final class Constants {
     public static final String UNSPECIFIED_HOST = "0.0.0.0";
 
     /**
+     * The name of the manifest ID parameter.
+     */
+    public static final String MANIFEST_ID = "manifestId";
+
+    /**
+     * The content-type header key.
+     */
+    public static final String CONTENT_TYPE = "content-type";
+
+    /**
+     * The media type for JSON (the format of IIIF manifests).
+     */
+    public static final String JSON_MEDIA_TYPE = "application/json";
+
+    /**
      * Private constructor for Constants class.
      */
     private Constants() {
     }
+
 }

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/HTTP.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/HTTP.java
@@ -9,8 +9,14 @@ public final class HTTP {
     /** Success response */
     public static final int OK = 200;
 
+    /** Success with no content */
+    public static final int SUCCESS_NO_CONTENT = 204;
+
     /** Created response */
     public static final int CREATED = 201;
+
+    /** Permission denied */
+    public static final int FORBIDDEN = 403;
 
     /** Not found response */
     public static final int NOT_FOUND = 404;

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/AbstractManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/AbstractManifestHandler.java
@@ -3,18 +3,31 @@ package edu.ucla.library.iiif.manifeststore.handlers;
 
 import com.amazonaws.regions.RegionUtils;
 
+import info.freelibrary.util.Logger;
 import info.freelibrary.vertx.s3.S3Client;
 
 import edu.ucla.library.iiif.manifeststore.Config;
+import edu.ucla.library.iiif.manifeststore.MessageCodes;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
+/**
+ * Creates an abstract handler so that other instantiated handlers can use its S3Client.
+ */
 abstract class AbstractManifestHandler implements Handler<RoutingContext> {
 
     protected S3Client myS3Client;
 
+    protected String myS3Bucket;
+
+    /**
+     * An abstract handler that initializes an S3 client.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig An application configuration
+     */
     AbstractManifestHandler(final Vertx aVertx, final JsonObject aConfig) {
         if (myS3Client == null) {
             final String s3AccessKey = aConfig.getString(Config.S3_ACCESS_KEY);
@@ -22,8 +35,13 @@ abstract class AbstractManifestHandler implements Handler<RoutingContext> {
             final String s3RegionName = aConfig.getString(Config.S3_REGION);
             final String s3Region = RegionUtils.getRegion(s3RegionName).getServiceEndpoint("s3");
 
+            getLogger().debug(MessageCodes.MFS_003, s3RegionName);
+
             myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey, s3Region);
+            myS3Bucket = aConfig.getString(Config.S3_BUCKET);
         }
     }
+
+    protected abstract Logger getLogger();
 
 }

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/DeleteManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/DeleteManifestHandler.java
@@ -1,7 +1,14 @@
 
 package edu.ucla.library.iiif.manifeststore.handlers;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.manifeststore.Constants;
+import edu.ucla.library.iiif.manifeststore.HTTP;
+import edu.ucla.library.iiif.manifeststore.MessageCodes;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -10,6 +17,8 @@ import io.vertx.ext.web.RoutingContext;
  * A IIIF manifest deleter.
  */
 public class DeleteManifestHandler extends AbstractManifestHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteManifestHandler.class, Constants.MESSAGES);
 
     /**
      * Creates a handler that deletes IIIF manifests from the manifest store.
@@ -24,9 +33,42 @@ public class DeleteManifestHandler extends AbstractManifestHandler {
     @Override
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
+        final HttpServerRequest request = aContext.request();
+        final String manifestID = request.getParam(Constants.MANIFEST_ID);
 
-        response.setStatusCode(200);
-        response.putHeader("content-type", "text/plain").end("Success!");
+        myS3Client.delete(myS3Bucket, manifestID, deleteResponse -> {
+            final int statusCode = deleteResponse.statusCode();
+
+            switch (statusCode) {
+                case HTTP.SUCCESS_NO_CONTENT:
+                    response.setStatusCode(HTTP.SUCCESS_NO_CONTENT);
+                    response.end();
+
+                    break;
+                case HTTP.FORBIDDEN:
+                    response.setStatusCode(HTTP.FORBIDDEN);
+                    response.end();
+
+                    break;
+                case HTTP.INTERNAL_SERVER_ERROR:
+                    LOGGER.error(MessageCodes.MFS_014, manifestID);
+
+                    response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
+                    response.end();
+
+                    break;
+                default:
+                    LOGGER.warn(MessageCodes.MFS_013, statusCode, manifestID);
+
+                    response.setStatusCode(statusCode);
+                    response.end();
+            }
+        });
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
     }
 
 }

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/GetManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/GetManifestHandler.java
@@ -1,7 +1,14 @@
 
 package edu.ucla.library.iiif.manifeststore.handlers;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.manifeststore.Constants;
+import edu.ucla.library.iiif.manifeststore.HTTP;
+import edu.ucla.library.iiif.manifeststore.MessageCodes;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -10,6 +17,8 @@ import io.vertx.ext.web.RoutingContext;
  * A IIIF manifest retriever.
  */
 public class GetManifestHandler extends AbstractManifestHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetManifestHandler.class, Constants.MESSAGES);
 
     /**
      * Creates a handler that returns IIIF manifests from the manifest store.
@@ -24,9 +33,42 @@ public class GetManifestHandler extends AbstractManifestHandler {
     @Override
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
+        final HttpServerRequest request = aContext.request();
+        final String manifestID = request.getParam(Constants.MANIFEST_ID);
 
-        response.setStatusCode(200);
-        response.putHeader("content-type", "text/plain").end("Success!");
+        myS3Client.get(myS3Bucket, manifestID, getResponse -> {
+            final int statusCode = getResponse.statusCode();
+
+            switch (statusCode) {
+                case HTTP.OK:
+                    getResponse.bodyHandler(bodyHandler -> {
+                        final String manifest = bodyHandler.getString(0, bodyHandler.length());
+
+                        response.setStatusCode(HTTP.OK);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.JSON_MEDIA_TYPE).end(manifest);
+                    });
+
+                    break;
+                case HTTP.NOT_FOUND:
+                    response.setStatusCode(HTTP.NOT_FOUND);
+                    response.setStatusMessage(LOGGER.getMessage(MessageCodes.MFS_009, manifestID));
+
+                    break;
+                case HTTP.INTERNAL_SERVER_ERROR:
+                    response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
+                    response.setStatusMessage(LOGGER.getMessage(MessageCodes.MFS_010, manifestID));
+
+                    break;
+                default:
+                    response.setStatusCode(statusCode);
+                    response.setStatusMessage(LOGGER.getMessage(MessageCodes.MFS_011, manifestID));
+            }
+        });
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
     }
 
 }

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/PostManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/PostManifestHandler.java
@@ -1,6 +1,10 @@
 
 package edu.ucla.library.iiif.manifeststore.handlers;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.manifeststore.Constants;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -10,6 +14,8 @@ import io.vertx.ext.web.RoutingContext;
  * A IIIF manifest creator.
  */
 public class PostManifestHandler extends AbstractManifestHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostManifestHandler.class, Constants.MESSAGES);
 
     /**
      * Creates a handler that creates IIIF manifests in the manifest store.
@@ -27,6 +33,11 @@ public class PostManifestHandler extends AbstractManifestHandler {
 
         response.setStatusCode(200);
         response.putHeader("content-type", "text/plain").end("Success!");
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
     }
 
 }

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/PutManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/handlers/PutManifestHandler.java
@@ -1,6 +1,10 @@
 
 package edu.ucla.library.iiif.manifeststore.handlers;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.manifeststore.Constants;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -10,6 +14,8 @@ import io.vertx.ext.web.RoutingContext;
  * A manifest creator or updater.
  */
 public class PutManifestHandler extends AbstractManifestHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PutManifestHandler.class, Constants.MESSAGES);
 
     /**
      * Creates a handler that creates or updates IIIF manifests in the manifest store.
@@ -29,4 +35,8 @@ public class PutManifestHandler extends AbstractManifestHandler {
         response.putHeader("content-type", "text/plain").end("Success!");
     }
 
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
+    }
 }

--- a/src/main/resources/manifeststore.yaml
+++ b/src/main/resources/manifeststore.yaml
@@ -68,7 +68,7 @@ paths:
     delete:
       operationId: deleteManifest
       responses:
-        '200':
+        '204':
           description: Deleted the manifest at the supplied ID
         '403':
           description: Forbidden

--- a/src/main/resources/manifeststore_messages.xml
+++ b/src/main/resources/manifeststore_messages.xml
@@ -2,10 +2,12 @@
 
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 
-<!--
+<!--<![CDATA[
   To process this file outside of a full build, run:
     mvn info.freelibrary:freelib-utils:generate-codes -DmessageFiles=src/main/resources/manifeststore_messages.xml
--->
+  Bash shell users can run the shorter form:
+    mvn info.freelibrary:freelib-utils:generate-codes -DmessageFiles=$(find src -name *_messages.xml)
+]]>-->
 
 <properties>
   <entry key="message-class-name">edu.ucla.library.iiif.manifeststore.MessageCodes</entry>
@@ -13,5 +15,23 @@
   <!-- Messages to be stored in the MessageCodes class -->
   <entry key="MFS-000">{}</entry>
   <entry key="MFS-001">S3 Client configured for region: {}</entry>
+  <entry key="MFS-002">Starting manifest-store test server on port: {}</entry>
+  <entry key="MFS-003">Creating S3 client for '{}' region</entry>
+  <entry key="MFS-004">Failed test should have returned '{}' response code instead of '{}'</entry>
+  <entry key="MFS-005">S3 client for testing created for '{}' region</entry>
+  <entry key="MFS-006">Putting '{}' (test object) into S3 bucket: {}</entry>
+  <entry key="MFS-007">S3 client credentials: {} | {}</entry>
+  <entry key="MFS-008">Test GetManifestHandler with a test manifest: {}</entry>
+  <entry key="MFS-009">Manifest not found: {}</entry>
+  <entry key="MFS-010">Internal server error while trying to retrieve manifest: {}</entry>
+  <entry key="MFS-011">Unexpected response code while trying to retrieve manifest: {}</entry>
+  <entry key="MFS-012">Test DeleteManifestHandler with a test manifest: {}</entry>
+  <entry key="MFS-013">Unexpected S3 response code: {} [manifest: {}]</entry>
+  <entry key="MFS-014">Internal server error while trying to delete manifest: {}</entry>
+  <entry key="MFS-015"></entry>
+  <entry key="MFS-016"></entry>
+  <entry key="MFS-017"></entry>
+  <entry key="MFS-018"></entry>
+  <entry key="MFS-019"></entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/manifeststore/handlers/AbstractManifestHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/manifeststore/handlers/AbstractManifestHandlerTest.java
@@ -1,0 +1,187 @@
+
+package edu.ucla.library.iiif.manifeststore.handlers;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.StringUtils;
+
+import edu.ucla.library.iiif.manifeststore.Config;
+import edu.ucla.library.iiif.manifeststore.MessageCodes;
+import edu.ucla.library.iiif.manifeststore.verticles.MainVerticle;
+import io.vertx.config.ConfigRetriever;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+abstract class AbstractManifestHandlerTest {
+
+    private static final String MANIFEST_FILE_NAME = "testManifest.json";
+
+    protected static final File MANIFEST_FILE = new File("src/test/resources", MANIFEST_FILE_NAME);
+
+    protected Vertx myVertx;
+
+    protected AmazonS3 myS3Client;
+
+    protected String myS3Bucket;
+
+    protected String myManifestID;
+
+    /**
+     * Test set up.
+     *
+     * @param aContext A testing context
+     */
+    @Before
+    public void setUp(final TestContext aContext) throws IOException {
+        final DeploymentOptions options = new DeploymentOptions();
+        final ServerSocket socket = new ServerSocket(0);
+        final int port = socket.getLocalPort();
+        final Future<AsyncResult> future = Future.future();
+        final Async asyncResult = aContext.async();
+
+        getLogger().debug(MessageCodes.MFS_002, port);
+
+        aContext.put(Config.HTTP_PORT, port);
+        options.setConfig(new JsonObject().put(Config.HTTP_PORT, port));
+        socket.close();
+
+        myManifestID = UUID.randomUUID().toString() + ".json";
+
+        // We only need to initialize our testing tools once; if done, skip
+        if (myVertx == null) {
+            initialize(future);
+        } else {
+            future.complete();
+        }
+
+        // If our testing tools have been initialized, start up our manifest store
+        future.setHandler(initialization -> {
+            if (initialization.succeeded()) {
+                deployManifestStore(aContext, asyncResult, options);
+            } else if (initialization.cause() != null) {
+                aContext.fail(initialization.cause());
+            } else {
+                aContext.fail();
+            }
+        });
+    }
+
+    /**
+     * Test tear down.
+     *
+     * @param aContext A testing context
+     */
+    @After
+    public void tearDown(final TestContext aContext) {
+        try {
+            // If object doesn't exist, this still completes successfully
+            myS3Client.deleteObject(myS3Bucket, myManifestID);
+        } catch (final SdkClientException details) {
+            aContext.fail(details);
+        }
+
+        myVertx.close(aContext.asyncAssertSuccess());
+    }
+
+    /**
+     * Gets logger specific to the handler test.
+     *
+     * @return Logger A logger
+     */
+    protected abstract Logger getLogger();
+
+    /**
+     * Deploy the manifest store to test against.
+     *
+     * @param aContext A test context
+     * @param aAsyncTask An asynchronous task that completes the setup
+     * @param aOpts Deployment options used to configure the manifest store
+     */
+    private void deployManifestStore(final TestContext aContext, final Async aAsyncTask,
+            final DeploymentOptions aOpts) {
+        myVertx.deployVerticle(MainVerticle.class.getName(), aOpts, deployment -> {
+            if (deployment.succeeded()) {
+                try {
+                    final String testManifest = StringUtils.read(MANIFEST_FILE);
+
+                    getLogger().debug(MessageCodes.MFS_006, myManifestID, myS3Bucket);
+                    myS3Client.putObject(myS3Bucket, myManifestID, testManifest);
+
+                    aAsyncTask.complete();
+                } catch (final IOException | SdkClientException details) {
+                    aContext.fail(details);
+                }
+            } else {
+                aContext.fail(deployment.cause());
+            }
+        });
+    }
+
+    /**
+     * Initialize our testing tools.
+     *
+     * @param aFuture A future to capture when the initialization is completed
+     * @throws IOException If there is trouble reading from the configuration file
+     */
+    private void initialize(final Future aFuture) throws IOException {
+        final ConfigRetriever configRetriever;
+
+        myVertx = Vertx.vertx();
+        configRetriever = ConfigRetriever.create(myVertx);
+
+        // We pull our application's configuration in for the S3 client configuration
+        configRetriever.getConfig(configuration -> {
+            if (configuration.failed()) {
+                aFuture.fail(configuration.cause());
+            } else {
+                final JsonObject config = configuration.result();
+
+                final String s3AccessKey = config.getString(Config.S3_ACCESS_KEY);
+                final String s3SecretKey = config.getString(Config.S3_SECRET_KEY);
+                final String s3Region = config.getString(Config.S3_REGION);
+
+                // Output access and secret key only if logging level is set to the lowest level
+                getLogger().trace(MessageCodes.MFS_007, s3AccessKey, s3SecretKey);
+
+                // Configure AWS credentials
+                final AWSCredentials awsCreds = new BasicAWSCredentials(s3AccessKey, s3SecretKey);
+                final AWSCredentialsProvider credsProvider = new AWSStaticCredentialsProvider(awsCreds);
+                final AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard();
+
+                // Create S3 client from supplied credentials and region
+                s3ClientBuilder.withCredentials(credsProvider).withRegion(s3Region);
+
+                myS3Client = s3ClientBuilder.build();
+                myS3Bucket = config.getString(Config.S3_BUCKET);
+
+                getLogger().debug(MessageCodes.MFS_005, s3Region);
+
+                aFuture.complete();
+            }
+        });
+    }
+
+}

--- a/src/test/java/edu/ucla/library/iiif/manifeststore/handlers/DeleteManifestHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/manifeststore/handlers/DeleteManifestHandlerTest.java
@@ -1,0 +1,80 @@
+
+package edu.ucla.library.iiif.manifeststore.handlers;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.manifeststore.Config;
+import edu.ucla.library.iiif.manifeststore.Constants;
+import edu.ucla.library.iiif.manifeststore.HTTP;
+import edu.ucla.library.iiif.manifeststore.MessageCodes;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class DeleteManifestHandlerTest extends AbstractManifestHandlerTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteManifestHandlerTest.class, Constants.MESSAGES);
+
+    /**
+     * Test the DeleteManifestHandler.
+     *
+     * @param aContext A testing context
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeleteManifestHandler(final TestContext aContext) throws IOException {
+        final Async asyncTask = aContext.async();
+        final int port = aContext.get(Config.HTTP_PORT);
+        final String testIDPath = "/manifests/" + myManifestID;
+
+        LOGGER.debug(MessageCodes.MFS_012, myManifestID);
+
+        myVertx.createHttpClient().delete(port, Constants.UNSPECIFIED_HOST, testIDPath, response -> {
+            final int statusCode = response.statusCode();
+
+            if (response.statusCode() == HTTP.SUCCESS_NO_CONTENT) {
+                aContext.assertFalse(myS3Client.doesObjectExist(myS3Bucket, myManifestID));
+                asyncTask.complete();
+            } else {
+                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_004, HTTP.SUCCESS_NO_CONTENT, statusCode));
+                asyncTask.complete();
+            }
+        }).end();
+    }
+
+    /**
+     * Confirm that a bad path request returns a 404 response.
+     *
+     * @param aContext A testing context
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testGetManifestHandler404(final TestContext aContext) {
+        final Async asyncTask = aContext.async();
+        final int port = aContext.get(Config.HTTP_PORT);
+        final String testIDPath = "/testIdentifier"; // path should start with: /manifests
+
+        myVertx.createHttpClient().delete(port, Constants.UNSPECIFIED_HOST, testIDPath, response -> {
+            final int statusCode = response.statusCode();
+
+            if (response.statusCode() != HTTP.NOT_FOUND) {
+                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_004, HTTP.NOT_FOUND, statusCode));
+            }
+
+            asyncTask.complete();
+        }).end();
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
+    }
+
+}

--- a/src/test/java/edu/ucla/library/iiif/manifeststore/handlers/GetManifestHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/manifeststore/handlers/GetManifestHandlerTest.java
@@ -1,0 +1,88 @@
+
+package edu.ucla.library.iiif.manifeststore.handlers;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
+
+import edu.ucla.library.iiif.manifeststore.Config;
+import edu.ucla.library.iiif.manifeststore.Constants;
+import edu.ucla.library.iiif.manifeststore.HTTP;
+import edu.ucla.library.iiif.manifeststore.MessageCodes;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class GetManifestHandlerTest extends AbstractManifestHandlerTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetManifestHandlerTest.class, Constants.MESSAGES);
+
+    /**
+     * Test the GetManifestHandler.
+     *
+     * @param aContext A testing context
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testGetManifestHandler(final TestContext aContext) throws IOException {
+        final String expectedManifest = StringUtils.read(MANIFEST_FILE);
+        final Async asyncTask = aContext.async();
+        final int port = aContext.get(Config.HTTP_PORT);
+        final String testIDPath = "/manifests/" + myManifestID;
+
+        LOGGER.debug(MessageCodes.MFS_008, myManifestID);
+
+        myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, testIDPath, response -> {
+            final int statusCode = response.statusCode();
+
+            if (response.statusCode() == HTTP.OK) {
+                response.bodyHandler(body -> {
+                    final String foundManifest = body.toString(StandardCharsets.UTF_8);
+
+                    // Check that what we retrieve is the same as what we stored
+                    aContext.assertEquals(expectedManifest, foundManifest);
+                    asyncTask.complete();
+                });
+            } else {
+                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_003, HTTP.OK, statusCode));
+                asyncTask.complete();
+            }
+        });
+    }
+
+    /**
+     * Confirm that a bad path request returns a 404 response.
+     *
+     * @param aContext A testing context
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testGetManifestHandler404(final TestContext aContext) {
+        final Async asyncTask = aContext.async();
+        final int port = aContext.get(Config.HTTP_PORT);
+        final String testIDPath = "/testIdentifier"; // path should start with: /manifests
+
+        myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, testIDPath, response -> {
+            final int statusCode = response.statusCode();
+
+            if (response.statusCode() != HTTP.NOT_FOUND) {
+                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_004, HTTP.NOT_FOUND, statusCode));
+            }
+
+            asyncTask.complete();
+        });
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
+    }
+
+}

--- a/src/test/resources/testManifest.json
+++ b/src/test/resources/testManifest.json
@@ -1,0 +1,1006 @@
+{
+    "@context": "http://iiif.io/api/image/2/context.json",
+    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/manifest",
+    "@type": "sc:Manifest",
+    "attribution": "Provided by the Blue Mountain Project at Princeton University",
+    "description": "a description",
+    "label": "Dada (Zurich, Switzerland), 3",
+    "license": "a license",
+    "metadata": [
+        {
+            "label": "title",
+            "value": "Dada (Zurich, Switzerland)"
+        },
+        {
+            "label": "display-date",
+            "value": "D\u00e9cembre 19181918-12"
+        },
+        {
+            "label": "part",
+            "value": "3"
+        }
+    ],
+    "seeAlso": {},
+    "sequences": [
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/sequence/normal",
+            "@type": "sc:Sequence",
+            "canvases": [
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page1",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page1",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0001.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0001.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "OUTSIDE_FRONT_COVER",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0002.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0002.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0003.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0003.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0004.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0004.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0005.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0005.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0006.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0006.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page7",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page7",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0007.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0007.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0008.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0008.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0009.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0009.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page10",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page10",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0010.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0010.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0011.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0011.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0012.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0012.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page13",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page13",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0013.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0013.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0014.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0014.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0015.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0015.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                },
+                {
+                    "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                    "@type": "sc:Canvas",
+                    "height": 6532,
+                    "images": [
+                        {
+                            "@type": "oa:Annotation",
+                            "motivation": "sc:painting",
+                            "on": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                            "resource": {
+                                "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0016.jp2/full/!200,200/0/default.jpg",
+                                "@type": "dctypes:Image",
+                                "format": "image/jp2",
+                                "height": 6532,
+                                "service": {
+                                    "@context": "http://iiif.io/api/image/2/context.json",
+                                    "@id": "http://libimages.princeton.edu/loris2/bluemountain/astore%2Fperiodicals/bmtnaae/issues/1918/12_01/delivery/bmtnaae_1918-12_01_0016.jp2",
+                                    "profile": "http://iiif.io/api/image/2/level1.json"
+                                },
+                                "width": 4668
+                            }
+                        }
+                    ],
+                    "label": "INSIDE",
+                    "width": 4668
+                }
+            ],
+            "label": "Normal Page Order",
+            "viewingDirection": "left-to-right",
+            "viewingHint": "paged"
+        }
+    ],
+    "service": {},
+    "structures": [
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page1",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page7",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page10",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page13",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16"
+            ],
+            "label": "Table of Contents"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c001",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page1",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page1",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page1"
+            ],
+            "label": "Untitled Text",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page1",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page1",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page1"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c003",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4"
+            ],
+            "label": "MANIFESTE DADA 1918.",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page2",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page3",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c007",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4"
+            ],
+            "label": "SOPRA UN QUADRO CUBISTA",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page4"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c009",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5"
+            ],
+            "label": "Regard",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c012",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5"
+            ],
+            "label": "Avant l'heure",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c013",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "label": "SALIVE AM\u00c9RICAINE",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c014",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "label": "Bois de E. PRAMPOLINI",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c045",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "label": "ABRI",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c015",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "label": "LA JOIE DES SEPT COULEURS: (Fragment)",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c019",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8"
+            ],
+            "label": "CRAYON BLEU: Po\u00e8me \u00e0 trois voix simultan\u00e9es",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c020",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8"
+            ],
+            "label": "Guillaume Apollinaire",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c021",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8"
+            ],
+            "label": "BOIS de H. RICHTER",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c022",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9"
+            ],
+            "label": "B\u00e2ton",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page9"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c028",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11"
+            ],
+            "label": "3 gravures sur bois par H. ARP",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page11"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c029",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12"
+            ],
+            "label": "GUILLAUME APOLLINAIRE",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c031",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12"
+            ],
+            "label": "circuit total par la lune et par la couleur",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c032",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page13",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page13"
+            ],
+            "label": "Gravure originale de MARCEL JANCO.",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page13",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page13"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c033",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "label": "\u00e0 Kisling",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c033a",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "label": "Bulletin",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c034",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "label": "Untitled Image",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c035",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "label": "Untitled Image",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c036",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15"
+            ],
+            "label": "LE MARIN",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c038",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15"
+            ],
+            "label": "CALENDRIER",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c039",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16"
+            ],
+            "label": "COW-BOY",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page16"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c042",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5"
+            ],
+            "label": "[Advertisement]",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c043",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5"
+            ],
+            "label": "[Advertisement]",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page5"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c044",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "label": "[Advertisement]",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page6"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c046",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12"
+            ],
+            "label": "[Advertisement]",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page12"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c047",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15"
+            ],
+            "label": "[Advertisement]",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page15"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c048",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8"
+            ],
+            "label": "Ad for Editions SIC",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page8"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        },
+        {
+            "@id": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/c049",
+            "@type": "sc:Range",
+            "canvases": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "label": "Ad for Tzara's 25 Poemes",
+            "members": [
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14",
+                "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/canvas/page14"
+            ],
+            "within": "http://bluemountain.princeton.edu/exist/restxq/iiif/bmtnaae_1918-12_01/range/toc"
+        }
+    ],
+    "within": "within URI"
+}


### PR DESCRIPTION
* Add manifest GET handler
* Add manifest DELETE handler
* Add GetManifestHandlerTest
* Add DeleteManifestHandlerTest
* Add abstract handler and test classes that other handlers and their tests can extend
* Update OpenAPI spec to have delete return 204 instead of 200 (because that's what S3 uses)

This ticket addresses IIIF-240 and IIIF-242.