### PR TITLE
[IIIF-279] Add docs view to app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,10 +176,38 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-web-resources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes/webroot</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/src/main/webroot</directory>
+                </resource>
+                <resource>
+                  <directory>${basedir}/src/main/resources</directory>
+                  <includes>
+                    <include>manifeststore.yaml</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- PMD is an extensible cross-language static code analyzer -->
       <plugin>
         <artifactId>maven-pmd-plugin</artifactId>
       </plugin>
+
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <dependencies>

--- a/src/main/java/edu/ucla/library/iiif/manifeststore/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/manifeststore/verticles/MainVerticle.java
@@ -22,6 +22,7 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
+import io.vertx.ext.web.handler.StaticHandler;
 
 /**
  * Main verticle that starts the application.
@@ -66,6 +67,9 @@ public class MainVerticle extends AbstractVerticle {
 
                         // After that, we can get a router that's been configured by our OpenAPI spec
                         router = factory.getRouter();
+
+                        // Serve Manifest Store documentation
+                        router.get("/docs/manifest-store/*").handler(StaticHandler.create().setWebRoot("webroot"));
 
                         // If an incoming request doesn't match one of our spec operations, it's treated as a 404;
                         // catch these generic 404s with the handler below and return more specific response codes

--- a/src/main/resources/manifeststore.yaml
+++ b/src/main/resources/manifeststore.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.0
+  version: 0.1.0
   title: Manifest Store API
   license:
     name: The 3-Clause BSD License
@@ -58,15 +58,6 @@ paths:
          schema:
            type: string
          description: The collection name
-  # Not yet implemented
-  /docs/manifest-store:
-    get:
-      operationId: getDocs
-      responses:
-        '200':
-          description: HTML documentation generated from the OpenAPI spec
-        '404':
-          description: Not found
   /{manifestId}/manifest:
     get:
       operationId: getManifest

--- a/src/main/webroot/index.html
+++ b/src/main/webroot/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Manifest-Store API Documentation</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='/docs/manifest-store/manifeststore.yaml'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>


### PR DESCRIPTION
This adds a route to serve the API docs up at: /docs/manifest-store/